### PR TITLE
feat: Allow to remove repository in /etc/apt/sources.list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 > * configures apt
 > * ensures packages
 > * add repositories
+> * optionnaly clean /etc/apt/sources.list
 > * add keys
 > * apt pinning
 > * manages unattended upgrades
@@ -188,6 +189,8 @@ apt_keys: []
 # apt_http_proxy_address:
 # HTTP pipeline depth (optional)
 # apt_http_pipeline_depth: 5
+# Clean /etc/apt/sources.list
+apt_clean_sources_list: false
 
 # Change Aptitudes solution costs, default is not to change anything
 # Mirror https://lists.debian.org/543FF3BD.1020609@zen.co.uk

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,6 +135,8 @@ apt_keys: []
 # apt_http_proxy_address:
 # HTTP pipeline depth (optional)
 # apt_http_pipeline_depth: 5
+# Clean /etc/apt/sources.list
+apt_clean_sources_list: false
 
 # Change Aptitudes solution costs, default is not to change anything
 # Mirror https://lists.debian.org/543FF3BD.1020609@zen.co.uk

--- a/meta/readme.yml
+++ b/meta/readme.yml
@@ -15,6 +15,7 @@ description: |
   > * ensures packages
   > * add repositories
   > * add keys
+  > * optionnaly clean /etc/apt/sources.list
   > * apt pinning
   > * manages unattended upgrades
   > * optionally alters solution cost

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -9,3 +9,10 @@
     state: "{{ item.state | default(omit) }}"
     update_cache: "{{ item.update_cache | default('yes') }}"
   with_items: "{{ apt_repositories }}"
+
+- name: Empty sources list
+  ansible.builtin.copy:
+    content: "# Ansible managed"
+    dest: /etc/apt/sources.list
+    mode: '0644'
+  when: apt_clean_sources_list


### PR DESCRIPTION
Allow to remove repository in /etc/apt/sources.list (which has certainly distribution repositories)

Add apt_clean_sources_list (set to false by default) to empty /etc/apt/sources.list (certainly filled with distribution Internet repositories which can be problematic in a strict-firewalled environment ).