### PR TITLE
enh: Allow to disable apt update (usefull in offline environment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ apt_dependencies:
   - python3-pycurl
 # sets the amount of time the cache is valid
 apt_cache_valid_time: 3600
+# Run apt-get update before installing/upgrading a package
+apt_cache_update: yes
 # upgrade system: safe | full | dist
 apt_upgrade: no
 # packages to ensure

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ apt_dependencies:
   - python3-pycurl
 # sets the amount of time the cache is valid
 apt_cache_valid_time: 3600
+# Run apt-get update before installing/upgrading a package
+apt_cache_update: yes
 # upgrade system: safe | full | dist
 apt_upgrade: no
 # packages to ensure

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -2,5 +2,5 @@
 
 - name: Updating cache
   apt:
-    update_cache: yes
+    update_cache: "{{ apt_cache_update | default('yes') }}"
     cache_valid_time: "{{ apt_cache_valid_time }}"

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -3,6 +3,6 @@
 - name: Upgrading system
   apt:
     upgrade: "{{ apt_upgrade }}"
-    update_cache: yes
+    update_cache: "{{ apt_cache_update | default('yes') }}"
     autoremove: "{{ apt_autoremove }}"
   when: (apt_upgrade == "safe") or (apt_upgrade == "full") or (apt_upgrade == "dist")


### PR DESCRIPTION
Add apt_cache_update variable (set to yes by default) in order to be able to avoid apt update.

Very useful in offline environment.