### PR TITLE
Fix clean source list

### DIFF
--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -1,4 +1,10 @@
 ---
+- name: Empty sources list
+  ansible.builtin.copy:
+    content: "# Ansible managed"
+    dest: /etc/apt/sources.list
+    mode: '0644'
+  when: apt_clean_sources_list
 
 - name: Adding apt repository
   apt_repository:
@@ -9,10 +15,3 @@
     state: "{{ item.state | default(omit) }}"
     update_cache: "{{ item.update_cache | default('yes') }}"
   with_items: "{{ apt_repositories }}"
-
-- name: Empty sources list
-  ansible.builtin.copy:
-    content: "# Ansible managed"
-    dest: /etc/apt/sources.list
-    mode: '0644'
-  when: apt_clean_sources_list

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -1,7 +1,8 @@
 ---
 - name: Empty sources list
   ansible.builtin.copy:
-    content: "# Ansible managed"
+    content: |
+      # Ansible managed
     dest: /etc/apt/sources.list
     mode: '0644'
   when: apt_clean_sources_list


### PR DESCRIPTION
If a source is present in `/etc/apt/sources.list` file and managed in `apt_repositories` variable, apt_repository command will not add it because source is already present, and 'Empty sources list' task will remove source from `/etc/apt/sources.list`, so apt source will no longer be available.

With this fix, `/etc/apt/sources.list`  cleanup will be performed (if asked with apt_clean_sources_list boolean) before adding new repositories. As there will be no more repository in `/etc/apt/sources.list`, all repositories present in `apt_repositories` variable will be configured.

minor fix in `/etc/apt/sources.list`  cleanup to avoid 'No newline at end of file'.