### PR TITLE
Use_deb822_If_Ansible_2.15

### DIFF
--- a/tasks/deb822.yml
+++ b/tasks/deb822.yml
@@ -1,0 +1,13 @@
+---
+- name: Configure deb822 repository
+  become: true
+  ansible.builtin.deb822_repository:
+    name: "{{ item.name }}"
+    types: "{{ item.type | default('deb') }}"
+    uris: "{{ item.uris }}"
+    suites: "{{ item.suites }}"
+    components: "{{ item.components }}"
+    signed_by: "{{ item.signed_by }}"
+    state: "{{ item.state | default('present') }}"
+  loop: "{{ apt_deb822_repositories }}"
+  register: deb822_repo

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -10,30 +10,23 @@
 
 - name: Adding apt repository
   become: true
-  apt_repository:
+  ansible.builtin.apt_repository:
     codename: "{{ item.codename | default(omit) }}"
     filename: "{{ item.filename | default(omit) }}"
     mode: "{{ item.mode | default(omit) }}"
     repo: "{{ item.repo | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     update_cache: "{{ item.update_cache | default('yes') }}"
-  with_items: "{{ apt_repositories }}"
+  loop: "{{ apt_repositories }}"
+  register: apt_repo
 
-- name: Configure deb822 repository
-  become: true
-  ansible.builtin.deb822_repository:
-    name: "{{ item.name }}"
-    types: "{{ item.type | default('deb') }}"
-    uris: "{{ item.uris }}"
-    suites: "{{ item.suites }}"
-    components: "{{ item.components }}"
-    signed_by: "{{ item.signed_by }}"
-    state: "{{ item.state | default('present') }}"
-  loop: "{{ apt_deb822_repositories }}"
-  register: repo
+- name: Include deb822 tasks only if Ansible >= 2.15
+  ansible.builtin.include_tasks: deb822.yml
+  when:
+    - ansible_version.full is version('2.15', '>=')
 
 - name: Apt update
   become: true
   ansible.builtin.apt:
     update_cache: yes
-  when: repo.changed
+  when: (apt_repo is defined and apt_repo.changed) or (deb822_repo is defined and deb822_repo.changed)


### PR DESCRIPTION
**Description**

Correction d’une erreur dans le rôle apt liée à l’utilisation du format deb822.

**Problème**

Le rôle échouait avec les versions d’Ansible inférieures à 2.15, car le module deb822 était chargé alors qu’il n’est pas supporté.

**Solution**

Ajout d’une condition pour n’utiliser deb822 que si la version d’Ansible est >= 2.15.

**Impact**
Corrige les erreurs sur les anciennes versions d’Ansible
Maintient la compatibilité avec les versions récentes